### PR TITLE
START5-35: Fix Control Character Input

### DIFF
--- a/Input.cpp
+++ b/Input.cpp
@@ -19,7 +19,7 @@ int inputInt(int lowerBound = INT_MIN, int upperBound = INT_MAX) {
 
 	while(true) {
 		cout << "Selection: ";
-		cin >> input;
+		getline(cin, input);
 
 		if (!TryParseStoi(input, parsedInput))
 			cout << "\nSelection is not a valid integer!\n";
@@ -29,11 +29,12 @@ int inputInt(int lowerBound = INT_MIN, int upperBound = INT_MAX) {
 			cout << "\nSelection is above upper bound!\n";
 		else
 			return parsedInput;
+
+		cin.clear();
 	}
 }
 
 void hang() {
 	cout << "\nPress Enter to continue...";
 	cin.ignore(numeric_limits<streamsize>::max(), '\n');
-	cin.get();
 }


### PR DESCRIPTION
- Use getline for input to only read one line and prevent <ctrl+l> from spilling onto multiple lines
- Use cin.clear() to reset the stream error flags after EOF signal from <ctrl+z>

Proof that <ctrl+z> is turning on EOF signal and causing the input to fail:
<img width="283" height="131" alt="START5-35_1" src="https://github.com/user-attachments/assets/bf0c2de8-19b2-4033-897b-06a8a8dfd565" />
